### PR TITLE
Merge to upgrade compatibility with pymatgen4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
 addons:
   apt:

--- a/mpinterfaces/instrument.py
+++ b/mpinterfaces/instrument.py
@@ -17,7 +17,7 @@ import subprocess
 import logging
 
 from pymatgen.io.vasp.inputs import Incar, Poscar, Potcar, Kpoints
-from pymatgen.io.vasp.sets import DictVaspInputSet
+from pymatgen.io.vasp.sets import DictSet
 
 from custodian.custodian import Job, ErrorHandler
 
@@ -35,7 +35,7 @@ sh.setFormatter(formatter)
 logger.addHandler(sh)
 
 
-class MPINTVaspInputSet(DictVaspInputSet):
+class MPINTVaspInputSet(DictSet):
     """
     defines the set of input required for a vasp job i.e
     create INCAR, POSCAR, POTCAR & KPOINTS files
@@ -75,7 +75,7 @@ class MPINTVaspInputSet(DictVaspInputSet):
         else:
             config_dict['KPOINTS'] = self.kpoints
         # self.user_incar_settings = self.incar.as_dict()
-        DictVaspInputSet.__init__(self, name, config_dict,
+        DictSet.__init__(self, name, config_dict,
                                   ediff_per_atom=False, **kwargs)
         if vis_logger:
             self.logger = vis_logger

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="mpinterfaces",
     version="1.2.0",
 
-    install_requires=["pymatgen==3.7.1", "FireWorks==1.3.3",
+    install_requires=["pymatgen==4.6.0", "FireWorks==1.3.3",
                       "custodian==1.0.1", "pymatgen-db==0.5.1",
                       "ase==3.11.0", "six", "matplotlib==1.5.0"],
     extras_require={"babel": ["openbabel", "pybel"],


### PR DESCRIPTION
Also drop python2.7 testing because pymatgen4.6 fails to build on python2.7. Backward compatibility is not a top priority now.